### PR TITLE
Added an exception to the license validator

### DIFF
--- a/license-exceptions.json
+++ b/license-exceptions.json
@@ -1,0 +1,7 @@
+{
+    "exceptions": {
+      "type-fest@0.20.2": {
+        "reason": "MIT and/or CC0-1.0 are compatible with Apache-2.0"
+      }
+    }
+  }


### PR DESCRIPTION
Added an exception to recognize type-fest@0.20.2 as compatible
with Apache License.